### PR TITLE
MySQL Service Endpoint Definition 

### DIFF
--- a/seds/mysql-sed/.helmignore
+++ b/seds/mysql-sed/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/seds/mysql-sed/Chart.yaml
+++ b/seds/mysql-sed/Chart.yaml
@@ -1,0 +1,12 @@
+annotations:
+  charts.openshift.io/archs: x86_64
+  charts.openshift.io/name: MYSQL Service Endpoint Definition (SED)
+  charts.openshift.io/provider: RedHat
+  charts.openshift.io/supportURL: https://github.com/redhat-developer/service-endpoint-definition
+apiVersion: v2
+appVersion: 0.1.0
+description: A Helm chart for MySQL Service Endpoint Definition (SED)
+kubeVersion: '>=1.20.0'
+name: mysql-sed
+type: application
+version: 0.1.0

--- a/seds/mysql-sed/README.md
+++ b/seds/mysql-sed/README.md
@@ -1,0 +1,9 @@
+This helm chart defines a MySQL Service Endpoint Definition (SED). When the SED is installed it will provide the user with the oportunity to provide connection information as well as credentials to authenticate. The following are the values that can be customized when the SED chart is installed:
+
+1. Host
+1. Port
+1. Username
+1. Password
+1. Databasename
+
+The SED Chart will render a secret with the connection information. This secret is compliant with the Service Binding Specification [Well Known Secret Entries](https://github.com/servicebinding/spec#well-known-secret-entries). Therefore, the secret rendered by MySQL SED Chart is a bindable service endpoint that can be projected to workloads using the Service [Binding Direct Secret Reference](https://github.com/servicebinding/spec#well-known-secret-entries).

--- a/seds/mysql-sed/templates/_helpers.tpl
+++ b/seds/mysql-sed/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mysql-sed.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mysql-sed.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mysql-sed.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mysql-sed.labels" -}}
+helm.sh/chart: {{ include "mysql-sed.chart" . }}
+{{ include "mysql-sed.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mysql-sed.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mysql-sed.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mysql-sed.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mysql-sed.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/seds/mysql-sed/templates/sed.yaml
+++ b/seds/mysql-sed/templates/sed.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name:  "io.servicebinding.{{ .Release.Name }}"
+type: servicebinding.io/mysql
+stringData:
+  type: mysql
+  provider: redhat
+  host: "{{ .Values.mysql.sed.host }}"
+  port: {{ .Values.mysql.sed.port | quote }}
+  username: "{{ .Values.mysql.sed.username }}"
+  password: "{{ .Values.mysql.sed.password }}"
+  database: "{{ .Values.mysql.sed.databasename }}"

--- a/seds/mysql-sed/templates/tests/test-mysql-connection.yaml
+++ b/seds/mysql-sed/templates/tests/test-mysql-connection.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-sed-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: "{{ .Release.Name }}-sed-test"
+      image: "registry.access.redhat.com/rhscl/mysql-80-rhel7:latest"
+      imagePullPolicy: "IfNotPresent"
+      env:
+        - name: MYSQL_HOST
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: host
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: username
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: password
+        - name: MYSQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: database
+        - name: MYSQL_PORT
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: port
+      command:
+        - /bin/bash
+        - -ec
+        - |
+          mysql  -h $MYSQL_HOST  -u$MYSQL_USER -p$MYSQL_PASSWORD -P$MYSQL_PORT -D$MYSQL_DATABASE -e "select 1"
+  restartPolicy: Never

--- a/seds/mysql-sed/values.schema.json
+++ b/seds/mysql-sed/values.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": [
+    "mysql"
+  ],
+  "properties": {
+    "mysql": {
+      "type": "object",
+      "required": [
+        "sed"
+      ],
+      "properties": {
+        "sed": {
+          "type": "object",
+          "required": [
+            "host",
+            "port",
+            "username",
+            "password",
+            "databasename"
+          ],
+          "properties": {
+            "host": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "username": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "password": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9-_./]+$"
+            },
+            "databasename": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/seds/mysql-sed/values.yaml
+++ b/seds/mysql-sed/values.yaml
@@ -1,0 +1,8 @@
+mysql:
+  sed:
+    host: host
+    port: 3306
+    username: root
+    password: password
+    databasename: database
+


### PR DESCRIPTION
This SED can be used in cases where the service was provisioned
either manually or via a Helm Chart. It will allow developer to
test their binding data in a standard manner regardless of how the
MySQL database was provisioned or the backend cloud. The
assumption here is that there is no CR representing the service in
kubernetes.