### PR TITLE
Added Elasticsearch Service Endpoint Definition

### DIFF
--- a/seds/elasticsearch-sed/.helmignore
+++ b/seds/elasticsearch-sed/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/seds/elasticsearch-sed/Chart.yaml
+++ b/seds/elasticsearch-sed/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: elasticsearch-sed
+description: A Helm chart for Elasticsearch Service Endpoint Definition (SED)
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+kubeVersion: ">=1.20.0"
+annotations:
+  charts.openshift.io/provider: RedHat
+  charts.openshift.io/name: Elasticsearch Service Endpoint Definition (SED)
+  charts.openshift.io/supportURL: https://github.com/redhat-developer/service-endpoint-definition
+  charts.openshift.io/archs: x86_64

--- a/seds/elasticsearch-sed/README.md
+++ b/seds/elasticsearch-sed/README.md
@@ -1,0 +1,9 @@
+This helm chart defines a Elasticsearch Service Endpoint Definition (SED). When the SED is installed it will provide the user with the oportunity to provide connection information as well as credentials to authenticate. The following are the values that can be customized when the SED chart is installed:
+
+1. Hostname
+2. Port
+3. User
+4. Password
+5. Cluster
+
+The SED Chart will render a secret with the connection information. This secret is compliant with the Service Binding Specification [Well Known Secret Entries](https://github.com/servicebinding/spec#well-known-secret-entries). Therefore, the secret rendered by Elasticsearch SED Chart is a bindable service endpoint that can be projected to workloads using the Service [Binding Direct Secret Reference](https://github.com/servicebinding/spec#well-known-secret-entries).

--- a/seds/elasticsearch-sed/templates/_helpers.tpl
+++ b/seds/elasticsearch-sed/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch-sed.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elasticsearch-sed.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elasticsearch-sed.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "elasticsearch-sed.labels" -}}
+helm.sh/chart: {{ include "elasticsearch-sed.chart" . }}
+{{ include "elasticsearch-sed.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "elasticsearch-sed.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "elasticsearch-sed.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "elasticsearch-sed.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "elasticsearch-sed.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/seds/elasticsearch-sed/templates/sed.yaml
+++ b/seds/elasticsearch-sed/templates/sed.yaml
@@ -1,0 +1,15 @@
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "io.servicebinding.{{ .Release.Name }}"
+type: servicebinding.io/elasticsearch
+stringData:
+  type: elasticsearch
+  provider: redhat
+  host: "{{ .Values.elasticsearch.sed.hostname }}"
+  port: {{ .Values.elasticsearch.sed.port | quote }}
+  cluster: "{{ .Values.elasticsearch.sed.cluster }}"
+  user: "{{ .Values.elasticsearch.sed.user }}"
+  password: "{{ .Values.elasticsearch.sed.password }}"
+

--- a/seds/elasticsearch-sed/templates/tests/test-elasticsearch-connection.yaml
+++ b/seds/elasticsearch-sed/templates/tests/test-elasticsearch-connection.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-sed-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: "{{ .Release.Name }}-sed-test"
+      image: "quay.io/opencloudio/icp-elasticsearch-oss@sha256:ad72aae5d293bb4f20d3dde1070334a2ce6ef9f40e8f58266a58f63f43ef6ebb"
+      imagePullPolicy: "IfNotPresent"
+      env:
+        - name: ELASTICSEARCH_HOST
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: host
+        - name: ELASTICSEARCH_PORT
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: port
+        - name: ELASTICSEARCH_CLUSTER
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: cluster
+        - name: ELASTICSEARCH_USER
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: user
+        - name: ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: password
+      command:
+      - /bin/bash
+      - -ec
+      - |
+        curl -XPUT -u $ELASTICSEARCH_USER:$ELASTICSEARCH_PASSWORD $ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT/test_index?pretty
+        curl -XGET -u $ELASTICSEARCH_USER:$ELASTICSEARCH_PASSWORD $ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT/_cluster/health?{{ .Values.clusterHealthCheckParams }}
+        curl -XDELETE -u $ELASTICSEARCH_USER:$ELASTICSEARCH_PASSWORD $ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT/test_index
+  restartPolicy: Never

--- a/seds/elasticsearch-sed/values.schema.json
+++ b/seds/elasticsearch-sed/values.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": [
+    "elasticsearch"
+  ],
+  "properties": {
+    "elasticsearch": {
+      "type": "object",
+      "required": [
+        "sed"
+      ],
+      "properties": {
+        "sed": {
+          "type": "object",
+          "required": [
+            "hostname",
+            "port",
+            "cluster",
+            "user",
+            "password"
+          ],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "cluster": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "user": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "password": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/seds/elasticsearch-sed/values.yaml
+++ b/seds/elasticsearch-sed/values.yaml
@@ -1,0 +1,8 @@
+elasticsearch:
+  sed:
+    hostname: myhostname
+    port: 9200
+    cluster: mycluster
+    user: user
+    password: password
+clusterHealthCheckParams: "wait_for_status=green&timeout=1s"


### PR DESCRIPTION

This SED can be used in cases where the service was provisioned
either manually or via a Helm Chart. It will allow developer to
test their binding data in a standard manner regardless of how the
Elasticsearch was provisioned or the backend cloud. The
assumption here is that there is no CR representing the service in
kubernetes.

Signed-off-by: Kartikey Mamgain <mamgainkartikey@gmail.com>