### PR TITLE
Redis Service Endpoint Definition (SED)

### DIFF
--- a/seds/redis-sed/.helmignore
+++ b/seds/redis-sed/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/seds/redis-sed/Chart.yaml
+++ b/seds/redis-sed/Chart.yaml
@@ -1,0 +1,12 @@
+annotations:
+  charts.openshift.io/archs: x86_64
+  charts.openshift.io/name: Redis Service Endpoint Definition (SED)
+  charts.openshift.io/provider: RedHat
+  charts.openshift.io/supportURL: https://github.com/redhat-developer/service-endpoint-definition
+apiVersion: v2
+appVersion: 1.0.0
+description: A Helm chart for Redis Service Endpoint Definition (SED)
+kubeVersion: '>=1.20.0'
+name: redis-sed
+type: application
+version: 1.0.0

--- a/seds/redis-sed/README.md
+++ b/seds/redis-sed/README.md
@@ -1,0 +1,6 @@
+This helm chart defines a Redis Service Endpoint Definition (SED). When the SED is installed it will provide the user with the oportunity to provide connection information as well as credentials to authenticate. The following are the values that can be customized when the SED chart is installed:
+
+1. Hostname
+2. Password
+
+The SED Chart will render a secret with the connection information. This secret is compliant with the Service Binding Specification [Well Known Secret Entries](https://github.com/servicebinding/spec#well-known-secret-entries). Therefore, the secret rendered by MongoDB SED Chart is a bindable service endpoint that can be projected to workloads using the Service [Binding Direct Secret Reference](https://github.com/servicebinding/spec#well-known-secret-entries).

--- a/seds/redis-sed/templates/_helpers.tpl
+++ b/seds/redis-sed/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redis-sed.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redis-sed.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redis-sed.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "redis-sed.labels" -}}
+helm.sh/chart: {{ include "redis-sed.chart" . }}
+{{ include "redis-sed.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "redis-sed.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mongosecret.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "redis-sed.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "redis-sed.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/seds/redis-sed/templates/sed.yaml
+++ b/seds/redis-sed/templates/sed.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name:  "io.servicebinding.{{ .Release.Name }}"
+type: servicebinding.io/redis
+stringData:
+  type: redis
+  provider: redhat
+  host: "{{ .Values.redis.sed.hostname }}"
+  password: "{{ .Values.redis.sed.password }}"

--- a/seds/redis-sed/templates/tests/test-redis-connection.yaml
+++ b/seds/redis-sed/templates/tests/test-redis-connection.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-sed-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: "{{ .Release.Name }}-sed-test"
+      image: "registry.connect.redhat.com/armory/redis:1.0.0-ubi"
+      imagePullPolicy: "IfNotPresent"
+      env:
+        - name: REDIS_HOST
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: host
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "io.servicebinding.{{ .Release.Name }}"
+              key: password
+      command:
+        - /bin/bash
+        - -ec
+        - |
+          REDISCLI_AUTH="$REDIS_PASSWORD" redis-cli -h myredis-master
+  restartPolicy: Never

--- a/seds/redis-sed/values.schema.json
+++ b/seds/redis-sed/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": [
+    "redis"
+  ],
+  "properties": {
+    "mongodb": {
+      "type": "object",
+      "required": [
+        "sed"
+      ],
+      "properties": {
+        "sed": {
+          "type": "object",
+          "required": [
+            "hostname",
+            "password"
+          ],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_./]+$"
+            },
+            "password": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9-_./]+$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/seds/redis-sed/values.yaml
+++ b/seds/redis-sed/values.yaml
@@ -1,0 +1,6 @@
+redis:
+  sed:
+    hostname: myredis-master
+    password: amfGAXXlA6
+
+


### PR DESCRIPTION
This SED can be used in cases where the service was provisioned
either manually or via a Helm Chart. It will allow developer to
test their binding data in a standard manner regardless of how the
Redis database was provisioned or the backend cloud. The
assumption here is that there is no CR representing the service in
kubernetes

Signed-off-by: Feny Mehta <fbm3307@gmail.com>